### PR TITLE
Add RNG interface

### DIFF
--- a/GearBox.Core.Tests/Model/Areas/MapTester.cs
+++ b/GearBox.Core.Tests/Model/Areas/MapTester.cs
@@ -5,6 +5,7 @@ using GearBox.Core.Model.Areas;
 using GearBox.Core.Model.GameObjects;
 using GearBox.Core.Model.GameObjects.Enemies;
 using GearBox.Core.Model.Units;
+using GearBox.Core.Utils;
 using Xunit;
 
 public class MapTester
@@ -14,7 +15,7 @@ public class MapTester
     [InlineData(0)]
     public void SizeInTilesMustBePositive(int sizeInTiles)
     {
-        Assert.Throws<ArgumentException>(() => new Map(Dimensions.InTiles(sizeInTiles)));
+        Assert.Throws<ArgumentException>(() => new Map(Dimensions.InTiles(sizeInTiles), new RandomNumberGenerator()));
     }
 
     [Fact]
@@ -52,7 +53,7 @@ public class MapTester
     [InlineData(100, 0)]
     public void CannotSetTileOutOfBounds(int x, int y)
     {
-        var sut = new Map(Dimensions.InTiles(20))
+        var sut = new Map(Dimensions.InTiles(20), new RandomNumberGenerator())
             .SetTileTypeForKey(1, AWall());
 
         Assert.Throws<ArgumentException>(() => sut.SetTileAt(Coordinates.FromTiles(x, y), 1));

--- a/GearBox.Core.Tests/Model/GameBuilderTester.cs
+++ b/GearBox.Core.Tests/Model/GameBuilderTester.cs
@@ -1,5 +1,6 @@
 using GearBox.Core.Config;
 using GearBox.Core.Model;
+using GearBox.Core.Utils;
 using Xunit;
 
 namespace GearBox.Core.Tests.Model;
@@ -9,7 +10,7 @@ public class GameBuilderTester
     [Fact]
     public void AreaNameMustBeUnique()
     {
-        var sut = new GameBuilder(new GearBoxConfig())
+        var sut = new GameBuilder(new GearBoxConfig(), new RandomNumberGenerator())
             .WithArea("foo", 1, area => area);
         
         Assert.Throws<ArgumentException>(() => sut.WithArea("foo", 1, area => area));

--- a/GearBox.Core.Tests/Model/GameObjects/Enemies/EnemyCharacterTester.cs
+++ b/GearBox.Core.Tests/Model/GameObjects/Enemies/EnemyCharacterTester.cs
@@ -1,0 +1,15 @@
+using GearBox.Core.Model.GameObjects.Enemies;
+using GearBox.Core.Model.GameObjects.Enemies.Ai;
+using Xunit;
+
+namespace GearBox.Core.Tests.Model.GameObjects.Enemies;
+
+public class EnemyCharacterTester
+{
+    [Fact]
+    public void Constructor_DefaultsToNullAI()
+    {
+        var sut = new EnemyCharacter("foo");
+        Assert.IsAssignableFrom<NullAiBehavior>(sut.AiBehavior);
+    }
+}

--- a/GearBox.Core.Tests/Model/GameObjects/Enemies/EnemyFactoryTester.cs
+++ b/GearBox.Core.Tests/Model/GameObjects/Enemies/EnemyFactoryTester.cs
@@ -3,6 +3,7 @@ using GearBox.Core.Model;
 using GearBox.Core.Model.GameObjects.Enemies;
 using GearBox.Core.Model.GameObjects.Enemies.Ai;
 using GearBox.Core.Model.Items;
+using GearBox.Core.Utils;
 using Xunit;
 
 namespace GearBox.Core.Tests.Model.GameObjects.Enemies;
@@ -13,7 +14,7 @@ public class EnemyFactoryTester
     public void MakeRandom_GivenAiNotDisabled_ShouldNotHaveNullAi()
     {
         var config = new GearBoxConfig();
-        var sut = new EnemyFactory(config, new EnemyRepositoryMock())
+        var sut = new EnemyFactory(config, new EnemyRepositoryMock(), new RandomNumberGeneratorMock())
             .Add("foo");
 
         var result = sut.MakeRandom(1) ?? throw new Exception("Mock should be configured to return non-null");
@@ -28,7 +29,7 @@ public class EnemyFactoryTester
         {
             DisableAI = true
         };
-        var sut = new EnemyFactory(config, new EnemyRepositoryMock())
+        var sut = new EnemyFactory(config, new EnemyRepositoryMock(), new RandomNumberGeneratorMock())
             .Add("foo");
 
         var result = sut.MakeRandom(1) ?? throw new Exception("Mock should be configured to return non-null");
@@ -41,5 +42,17 @@ public class EnemyFactoryTester
         public IEnemyRepository Add(string name, Color color, Func<LootTableBuilder, LootTableBuilder> loot) => this;
 
         public EnemyCharacter? GetEnemyByName(string name, int level) => new EnemyCharacter(name, level);
+    }
+
+    private class RandomNumberGeneratorMock : IRandomNumberGenerator
+    {
+        private readonly RandomNumberGenerator _inner = new();
+
+        public bool CheckChance(double percentChance)
+        {
+            throw new NotImplementedException();
+        }
+        
+        public T ChooseRandom<T>(List<T> options) => _inner.ChooseRandom(options);
     }
 }

--- a/GearBox.Core.Tests/Model/GameObjects/Enemies/EnemyFactoryTester.cs
+++ b/GearBox.Core.Tests/Model/GameObjects/Enemies/EnemyFactoryTester.cs
@@ -14,7 +14,7 @@ public class EnemyFactoryTester
     public void MakeRandom_GivenAiNotDisabled_ShouldNotHaveNullAi()
     {
         var config = new GearBoxConfig();
-        var sut = new EnemyFactory(config, new EnemyRepositoryMock(), new RandomNumberGeneratorMock())
+        var sut = new EnemyFactory(config, new EnemyRepositoryMock(), new RandomNumberGenerator())
             .Add("foo");
 
         var result = sut.MakeRandom(1) ?? throw new Exception("Mock should be configured to return non-null");
@@ -29,7 +29,7 @@ public class EnemyFactoryTester
         {
             DisableAI = true
         };
-        var sut = new EnemyFactory(config, new EnemyRepositoryMock(), new RandomNumberGeneratorMock())
+        var sut = new EnemyFactory(config, new EnemyRepositoryMock(), new RandomNumberGenerator())
             .Add("foo");
 
         var result = sut.MakeRandom(1) ?? throw new Exception("Mock should be configured to return non-null");
@@ -42,17 +42,5 @@ public class EnemyFactoryTester
         public IEnemyRepository Add(string name, Color color, Func<LootTableBuilder, LootTableBuilder> loot) => this;
 
         public EnemyCharacter? GetEnemyByName(string name, int level) => new EnemyCharacter(name, level);
-    }
-
-    private class RandomNumberGeneratorMock : IRandomNumberGenerator
-    {
-        private readonly RandomNumberGenerator _inner = new();
-
-        public bool CheckChance(double percentChance)
-        {
-            throw new NotImplementedException();
-        }
-        
-        public T ChooseRandom<T>(List<T> options) => _inner.ChooseRandom(options);
     }
 }

--- a/GearBox.Core.Tests/Model/Items/LootTableTester.cs
+++ b/GearBox.Core.Tests/Model/Items/LootTableTester.cs
@@ -1,4 +1,5 @@
 using GearBox.Core.Model.Items;
+using GearBox.Core.Utils;
 using Xunit;
 
 namespace GearBox.Core.Tests.Model.Items;
@@ -11,7 +12,7 @@ public class LootTableTester
         var expected = new Material("foo");
         var sut = new LootTable([
             new LootOption(1, ItemUnion.Of(expected))
-        ]);
+        ], new RandomNumberGenerator());
 
         var inventory = sut.GetRandomLoot();
         var actual = inventory.Materials.Content.First().Item;
@@ -26,7 +27,7 @@ public class LootTableTester
         var expected = new Equipment<WeaponStats>("foo", new WeaponStats());
         var sut = new LootTable([
             new LootOption(1, ItemUnion.Of(expected))
-        ]);
+        ], new RandomNumberGenerator());
 
         var inventory = sut.GetRandomLoot();
         var actual = inventory.Weapons.Content.First().Item;

--- a/GearBox.Core.Tests/Server/GameServerTester.cs
+++ b/GearBox.Core.Tests/Server/GameServerTester.cs
@@ -2,6 +2,7 @@ using GearBox.Core.Config;
 using GearBox.Core.Model;
 using GearBox.Core.Model.GameObjects.Player;
 using GearBox.Core.Server;
+using GearBox.Core.Utils;
 using Xunit;
 
 namespace GearBox.Core.Tests.Server;
@@ -93,7 +94,7 @@ public class GameServerTester
 
     public static IGame MakeGame()
     {
-        var result = new GameBuilder(new GearBoxConfig())
+        var result = new GameBuilder(new GearBoxConfig(), new RandomNumberGenerator())
             .WithArea("foo", 1, area => area.WithMap(new()))
             .Build();
         return result;

--- a/GearBox.Core/Model/Areas/Area.cs
+++ b/GearBox.Core/Model/Areas/Area.cs
@@ -42,7 +42,7 @@ public class Area : IArea
         _game = game ?? new Game();
         _map = map ?? new();
         Shops = shops ?? [];
-        _loot = loot ?? new LootTable([]);
+        _loot = loot ?? new LootTable([], new RandomNumberGenerator());
         _enemyFactory = enemyFactory ?? EnemyFactory.MakeDefault();
         _exits = exits ?? [];
 

--- a/GearBox.Core/Model/Areas/AreaBuilder.cs
+++ b/GearBox.Core/Model/Areas/AreaBuilder.cs
@@ -3,6 +3,7 @@ using GearBox.Core.Model.Items;
 using GearBox.Core.Model.Items.Infrastructure;
 using GearBox.Core.Model.Items.Shops;
 using GearBox.Core.Model.Units;
+using GearBox.Core.Utils;
 
 namespace GearBox.Core.Model.Areas;
 
@@ -16,12 +17,12 @@ public class AreaBuilder
     private readonly IEnemyFactory _enemies;
     private readonly List<IExit> _exits = [];
 
-    public AreaBuilder(string name, int level, IItemFactory itemFactory, IEnemyFactory enemies)
+    public AreaBuilder(string name, int level, IItemFactory itemFactory, IEnemyFactory enemies, IRandomNumberGenerator rng)
     {
         Name = name;
         _level = level;
         _itemFactory = itemFactory;
-        _lootBuilder = new(itemFactory);
+        _lootBuilder = new(itemFactory, rng);
         _enemies = enemies;
     }
 

--- a/GearBox.Core/Model/Areas/Map.cs
+++ b/GearBox.Core/Model/Areas/Map.cs
@@ -2,6 +2,7 @@ using GearBox.Core.Model.GameObjects;
 using GearBox.Core.Model.Json;
 using GearBox.Core.Model.Json.AreaUpdate;
 using GearBox.Core.Model.Units;
+using GearBox.Core.Utils;
 
 namespace GearBox.Core.Model.Areas;
 
@@ -10,16 +11,17 @@ namespace GearBox.Core.Model.Areas;
 /// </summary>
 public class Map : ISerializable<MapJson>
 {
+    private readonly IRandomNumberGenerator _rng;
     private readonly int[,] _tileMap;
     private readonly Dictionary<int, TileType> _tileTypes = [];
 
 
-    public Map() : this(Dimensions.InTiles(20))
+    public Map() : this(Dimensions.InTiles(20), new RandomNumberGenerator())
     {
 
     }
 
-    public Map(Dimensions dimensions)
+    public Map(Dimensions dimensions, IRandomNumberGenerator rng)
     {
         var width = dimensions.WidthInTiles;
         var height = dimensions.HeightInTiles;
@@ -31,6 +33,8 @@ public class Map : ISerializable<MapJson>
         {
             throw new ArgumentException("height must be positive");
         }
+
+        _rng = rng;
         _tileMap = new int[height, width]; // initializes all to 0
         _tileTypes[0] = new TileType(Color.BLUE, TileHeight.FLOOR);
         Width = Distance.FromTiles(_tileMap.GetLength(1));
@@ -162,9 +166,8 @@ public class Map : ISerializable<MapJson>
 
     public Coordinates GetRandomFloorTile()
     {
-        var random = new Random();
-        var x = random.Next(Width.InTiles);
-        var y = random.Next(Height.InTiles);
+        var x = _rng.Next(Width.InTiles);
+        var y = _rng.Next(Height.InTiles);
         var source = Coordinates.FromTiles(x, y);
         return FindFloorTileAround(source) ?? throw new Exception("No floor tiles");
     }

--- a/GearBox.Core/Model/GameBuilder.cs
+++ b/GearBox.Core/Model/GameBuilder.cs
@@ -19,7 +19,7 @@ public class GameBuilder : IGameBuilder
     {
         _config = config;
         _rng = rng;
-        Enemies = new EnemyRepository(Items);
+        Enemies = new EnemyRepository(Items, rng);
     }
 
     public IActiveAbilityFactory Actives { get; init; } = new ActiveAbilityFactory();
@@ -40,7 +40,7 @@ public class GameBuilder : IGameBuilder
             throw new ArgumentException("Name must be unique within each game", nameof(name));
         }
 
-        _areas.Add(defineArea(new AreaBuilder(name, level, Items, new EnemyFactory(_config, Enemies, _rng))));
+        _areas.Add(defineArea(new AreaBuilder(name, level, Items, new EnemyFactory(_config, Enemies, _rng), _rng)));
         return this;
     }
 

--- a/GearBox.Core/Model/GameBuilder.cs
+++ b/GearBox.Core/Model/GameBuilder.cs
@@ -4,6 +4,7 @@ using GearBox.Core.Model.Areas;
 using GearBox.Core.Model.GameObjects.Enemies;
 using GearBox.Core.Model.Items.Crafting;
 using GearBox.Core.Model.Items.Infrastructure;
+using GearBox.Core.Utils;
 
 namespace GearBox.Core.Model;
 
@@ -36,7 +37,11 @@ public class GameBuilder : IGameBuilder
         {
             throw new ArgumentException("Name must be unique within each game", nameof(name));
         }
-        _areas.Add(defineArea(new AreaBuilder(name, level, Items, new EnemyFactory(_config, Enemies))));
+
+        // inject this instead if needed
+        var rng = new RandomNumberGenerator();
+
+        _areas.Add(defineArea(new AreaBuilder(name, level, Items, new EnemyFactory(_config, Enemies, rng))));
         return this;
     }
 

--- a/GearBox.Core/Model/GameBuilder.cs
+++ b/GearBox.Core/Model/GameBuilder.cs
@@ -11,12 +11,14 @@ namespace GearBox.Core.Model;
 public class GameBuilder : IGameBuilder
 {
     private readonly GearBoxConfig _config;
+    private readonly IRandomNumberGenerator _rng;
     private readonly HashSet<CraftingRecipe> _craftingRecipes = [];
     private readonly List<AreaBuilder> _areas = []; // must be ordered so the first area added is the default area
 
-    public GameBuilder(GearBoxConfig config)
+    public GameBuilder(GearBoxConfig config, IRandomNumberGenerator rng)
     {
         _config = config;
+        _rng = rng;
         Enemies = new EnemyRepository(Items);
     }
 
@@ -38,10 +40,7 @@ public class GameBuilder : IGameBuilder
             throw new ArgumentException("Name must be unique within each game", nameof(name));
         }
 
-        // inject this instead if needed
-        var rng = new RandomNumberGenerator();
-
-        _areas.Add(defineArea(new AreaBuilder(name, level, Items, new EnemyFactory(_config, Enemies, rng))));
+        _areas.Add(defineArea(new AreaBuilder(name, level, Items, new EnemyFactory(_config, Enemies, _rng))));
         return this;
     }
 

--- a/GearBox.Core/Model/GameObjects/Enemies/Ai/AttackAiBehavior.cs
+++ b/GearBox.Core/Model/GameObjects/Enemies/Ai/AttackAiBehavior.cs
@@ -1,6 +1,7 @@
 using GearBox.Core.Model.Areas;
 using GearBox.Core.Model.GameObjects.Player;
 using GearBox.Core.Model.Units;
+using GearBox.Core.Utils;
 
 namespace GearBox.Core.Model.GameObjects.Enemies.Ai;
 
@@ -8,17 +9,19 @@ public class AttackAiBehavior : IAiBehavior
 {
     private readonly EnemyCharacter _controlling;
     private readonly PlayerCharacter _attacking;
+    private readonly IRandomNumberGenerator _rng;
 
-    public AttackAiBehavior(EnemyCharacter controlling, PlayerCharacter attacking)
+    public AttackAiBehavior(EnemyCharacter controlling, PlayerCharacter attacking, IRandomNumberGenerator rng)
     {
         _controlling = controlling;
         _attacking = attacking;
+        _rng = rng;
         attacking.AreaChanged += HandleAreaChangedEvent;
     }
 
     private void HandleAreaChangedEvent(object? sender, AreaChangedEventArgs e)
     {
-        _controlling.AiBehavior = new WanderAiBehavior(_controlling);
+        _controlling.AiBehavior = new WanderAiBehavior(_controlling, _rng);
         e.WhoChangedAreas.AreaChanged -= HandleAreaChangedEvent;
     }
 
@@ -26,7 +29,7 @@ public class AttackAiBehavior : IAiBehavior
     {
         if (_attacking.Termination.IsTerminated)
         {
-            _controlling.AiBehavior = new WanderAiBehavior(_controlling);
+            _controlling.AiBehavior = new WanderAiBehavior(_controlling, _rng);
         }
         else if (_controlling.BasicAttack.CanReach(_controlling, _attacking))
         {
@@ -37,7 +40,7 @@ public class AttackAiBehavior : IAiBehavior
         }
         else
         {
-            _controlling.AiBehavior = new PursueAiBehavior(_controlling, _attacking);
+            _controlling.AiBehavior = new PursueAiBehavior(_controlling, _attacking, _rng);
         }
     }
 }

--- a/GearBox.Core/Model/GameObjects/Enemies/Ai/PursueAiBehavior.cs
+++ b/GearBox.Core/Model/GameObjects/Enemies/Ai/PursueAiBehavior.cs
@@ -1,6 +1,7 @@
 using GearBox.Core.Model.Areas;
 using GearBox.Core.Model.GameObjects.Player;
 using GearBox.Core.Model.Units;
+using GearBox.Core.Utils;
 
 namespace GearBox.Core.Model.GameObjects.Enemies.Ai;
 
@@ -8,17 +9,19 @@ public class PursueAiBehavior : IAiBehavior
 {
     private readonly EnemyCharacter _controlling;
     private readonly PlayerCharacter _pursuing;
+    private readonly IRandomNumberGenerator _rng;
 
-    public PursueAiBehavior(EnemyCharacter controlling, PlayerCharacter pursuing)
+    public PursueAiBehavior(EnemyCharacter controlling, PlayerCharacter pursuing, IRandomNumberGenerator rng)
     {
         _controlling = controlling;
         _pursuing = pursuing;
+        _rng = rng;
         pursuing.AreaChanged += HandleAreaChangedEvent;
     }
 
     private void HandleAreaChangedEvent(object? sender, AreaChangedEventArgs e)
     {
-        _controlling.AiBehavior = new WanderAiBehavior(_controlling);
+        _controlling.AiBehavior = new WanderAiBehavior(_controlling, _rng);
         e.WhoChangedAreas.AreaChanged -= HandleAreaChangedEvent;
     }
 
@@ -31,7 +34,7 @@ public class PursueAiBehavior : IAiBehavior
         // check if close enough to attack
         if (_controlling.BasicAttack.CanReach(_controlling, _pursuing))
         {
-            _controlling.AiBehavior = new AttackAiBehavior(_controlling, _pursuing);
+            _controlling.AiBehavior = new AttackAiBehavior(_controlling, _pursuing, _rng);
         }
     }
 }

--- a/GearBox.Core/Model/GameObjects/Enemies/Ai/WanderAiBehavior.cs
+++ b/GearBox.Core/Model/GameObjects/Enemies/Ai/WanderAiBehavior.cs
@@ -1,26 +1,29 @@
 
 using GearBox.Core.Model.GameObjects.Player;
 using GearBox.Core.Model.Units;
+using GearBox.Core.Utils;
 
 namespace GearBox.Core.Model.GameObjects.Enemies.Ai;
 
 public class WanderAiBehavior : IAiBehavior
 {
     private readonly EnemyCharacter _target;
+    private readonly IRandomNumberGenerator _rng;
     private int _framesLeftToWander;
 
-    public WanderAiBehavior(EnemyCharacter target)
+    public WanderAiBehavior(EnemyCharacter target, IRandomNumberGenerator rng)
     {
         _target = target;
+        _rng = rng;
         ChooseNewDirection();
     }
 
     private void ChooseNewDirection()
     {
-        var seconds = Random.Shared.Next(3, 20+1);
+        var seconds = _rng.Next(3, 20+1);
         _framesLeftToWander = Duration.FromSeconds(seconds).InFrames;
 
-        var angle = Random.Shared.Next(360);
+        var angle = _rng.Next(360);
         var direction = Direction.FromBearingDegrees(angle);
         _target.StartMovingIn(direction);
     }
@@ -36,7 +39,7 @@ public class WanderAiBehavior : IAiBehavior
         var nearestEnemy = _target.CurrentArea?.GetNearestPlayerTo(_target);
         if (nearestEnemy != null && IsCloseEnoughToSee(nearestEnemy))
         {
-            _target.AiBehavior = new PursueAiBehavior(_target, nearestEnemy);
+            _target.AiBehavior = new PursueAiBehavior(_target, nearestEnemy, _rng);
         }
     }
 

--- a/GearBox.Core/Model/GameObjects/Enemies/EnemyCharacter.cs
+++ b/GearBox.Core/Model/GameObjects/Enemies/EnemyCharacter.cs
@@ -7,7 +7,7 @@ public class EnemyCharacter : Character
 {
     public EnemyCharacter(string name, int level = 1, Color? color = null, LootTable? loot = null) : base(name, level, color)
     {
-        AiBehavior = new WanderAiBehavior(this);
+        AiBehavior = new NullAiBehavior();
         Loot = loot ?? new LootTable([]);
     }
 

--- a/GearBox.Core/Model/GameObjects/Enemies/EnemyCharacter.cs
+++ b/GearBox.Core/Model/GameObjects/Enemies/EnemyCharacter.cs
@@ -1,5 +1,6 @@
 using GearBox.Core.Model.GameObjects.Enemies.Ai;
 using GearBox.Core.Model.Items;
+using GearBox.Core.Utils;
 
 namespace GearBox.Core.Model.GameObjects.Enemies;
 
@@ -8,7 +9,7 @@ public class EnemyCharacter : Character
     public EnemyCharacter(string name, int level = 1, Color? color = null, LootTable? loot = null) : base(name, level, color)
     {
         AiBehavior = new NullAiBehavior();
-        Loot = loot ?? new LootTable([]);
+        Loot = loot ?? new LootTable([], new RandomNumberGenerator());
     }
 
     public IAiBehavior AiBehavior { get; set; }

--- a/GearBox.Core/Model/GameObjects/Enemies/EnemyFactory.cs
+++ b/GearBox.Core/Model/GameObjects/Enemies/EnemyFactory.cs
@@ -40,10 +40,9 @@ public class EnemyFactory : IEnemyFactory
         var name = _rng.ChooseRandom(_names);
         var result = _allEnemies.GetEnemyByName(name, level) ?? throw new Exception($"Bad enemy name: {name}");
 
-        if (_config.DisableAI)
+        if (!_config.DisableAI)
         {
-            result.AiBehavior = new NullAiBehavior();
-            result.StopMoving();
+            result.AiBehavior = new WanderAiBehavior(result, _rng);
         }
 
         result.Killed += (sender, e) => HandleKilled(result, e);

--- a/GearBox.Core/Model/GameObjects/Enemies/EnemyFactory.cs
+++ b/GearBox.Core/Model/GameObjects/Enemies/EnemyFactory.cs
@@ -22,7 +22,7 @@ public class EnemyFactory : IEnemyFactory
         _rng = rng;
     }
 
-    public static EnemyFactory MakeDefault() => new EnemyFactory(new GearBoxConfig(), new EnemyRepository(new ItemFactory()), new RandomNumberGenerator());
+    public static EnemyFactory MakeDefault() => new EnemyFactory(new GearBoxConfig(), new EnemyRepository(new ItemFactory(), new RandomNumberGenerator()), new RandomNumberGenerator());
 
     public IEnemyFactory Add(string name)
     {

--- a/GearBox.Core/Model/GameObjects/Enemies/EnemyRepository.cs
+++ b/GearBox.Core/Model/GameObjects/Enemies/EnemyRepository.cs
@@ -1,21 +1,24 @@
 using GearBox.Core.Model.Items;
 using GearBox.Core.Model.Items.Infrastructure;
+using GearBox.Core.Utils;
 
 namespace GearBox.Core.Model.GameObjects.Enemies;
 
 public class EnemyRepository : IEnemyRepository
 {
     private readonly IItemFactory _itemFactory;
+    private readonly IRandomNumberGenerator _rng;
     private readonly Dictionary<string, EnemyCharacterBuilder> _enemyBuilders = [];
 
-    public EnemyRepository(IItemFactory itemFactory)
+    public EnemyRepository(IItemFactory itemFactory, IRandomNumberGenerator rng)
     {
         _itemFactory = itemFactory;
+        _rng = rng;
     }
 
     public IEnemyRepository Add(string name, Color color, Func<LootTableBuilder, LootTableBuilder> loot)
     {
-        var lootTableBuilder = new LootTableBuilder(_itemFactory);
+        var lootTableBuilder = new LootTableBuilder(_itemFactory, _rng);
         var enemyBuilder = new EnemyCharacterBuilder(name, color, loot(lootTableBuilder));
         _enemyBuilders[name] = enemyBuilder;
         return this;

--- a/GearBox.Core/Model/Items/LootTable.cs
+++ b/GearBox.Core/Model/Items/LootTable.cs
@@ -1,3 +1,5 @@
+using GearBox.Core.Utils;
+
 namespace GearBox.Core.Model.Items;
 
 /// <summary>
@@ -6,17 +8,19 @@ namespace GearBox.Core.Model.Items;
 public class LootTable
 {
     private readonly List<LootOption> _lootOptions = [];
+    private readonly IRandomNumberGenerator _rng;
 
-    public LootTable(List<LootOption> options)
+    public LootTable(List<LootOption> options, IRandomNumberGenerator rng)
     {
         _lootOptions = options;
+        _rng = rng;
     }
 
     public Inventory GetRandomLoot()
     {
         var result = new Inventory();
         var numItems = _lootOptions.Any()
-            ? Random.Shared.Next(0, 3) + 1
+            ? _rng.Next(0, 3) + 1
             : 0;
         for (int i = 0; i < numItems; i++)
         {
@@ -32,7 +36,7 @@ public class LootTable
     private LootOption ChooseRandomLootOption()
     {
         var totalWeight = _lootOptions.Sum(x => x.Weight);
-        var randomNumber = Random.Shared.Next(totalWeight);
+        var randomNumber = _rng.Next(totalWeight);
         foreach (var weightedItem in _lootOptions)
         {
             if (weightedItem.Weight > randomNumber)

--- a/GearBox.Core/Model/Items/LootTableBuilder.cs
+++ b/GearBox.Core/Model/Items/LootTableBuilder.cs
@@ -1,15 +1,18 @@
 using GearBox.Core.Model.Items.Infrastructure;
+using GearBox.Core.Utils;
 
 namespace GearBox.Core.Model.Items;
 
 public class LootTableBuilder
 {
     private readonly IItemFactory _itemFactory;
+    private readonly IRandomNumberGenerator _rng;
     private readonly List<LootOption> _lootOptions = [];
 
-    public LootTableBuilder(IItemFactory itemFactory)
+    public LootTableBuilder(IItemFactory itemFactory, IRandomNumberGenerator rng)
     {
         _itemFactory = itemFactory;
+        _rng = rng;
     }
 
     public LootTableBuilder AddItem(string name)
@@ -33,7 +36,7 @@ public class LootTableBuilder
                 gold => opt
             ))
             .ToList();
-        var result = new LootTable(lootOptions);
+        var result = new LootTable(lootOptions, _rng);
         return result;
     }
 }

--- a/GearBox.Core/Utils/IRandomNumberGenerator.cs
+++ b/GearBox.Core/Utils/IRandomNumberGenerator.cs
@@ -8,6 +8,11 @@ public interface IRandomNumberGenerator
     int Next(int max);
 
     /// <summary>
+    /// Returns a random integer that is within a specified range.
+    /// </summary>
+    int Next(int minValue, int maxValue);
+
+    /// <summary>
     /// For example, CheckChance(0.33) returns true 33% of the time
     /// </summary>
     bool CheckChance(double percentChance);

--- a/GearBox.Core/Utils/IRandomNumberGenerator.cs
+++ b/GearBox.Core/Utils/IRandomNumberGenerator.cs
@@ -3,6 +3,11 @@ namespace GearBox.Core.Utils;
 public interface IRandomNumberGenerator
 {
     /// <summary>
+    /// Returns a non-negative int less than max
+    /// </summary>
+    int Next(int max);
+
+    /// <summary>
     /// For example, CheckChance(0.33) returns true 33% of the time
     /// </summary>
     bool CheckChance(double percentChance);

--- a/GearBox.Core/Utils/IRandomNumberGenerator.cs
+++ b/GearBox.Core/Utils/IRandomNumberGenerator.cs
@@ -1,0 +1,14 @@
+namespace GearBox.Core.Utils;
+
+public interface IRandomNumberGenerator
+{
+    /// <summary>
+    /// For example, CheckChance(0.33) returns true 33% of the time
+    /// </summary>
+    bool CheckChance(double percentChance);
+
+    /// <summary>
+    /// Returns a random option from the given options
+    /// </summary>
+    T ChooseRandom<T>(List<T> options);
+}

--- a/GearBox.Core/Utils/RandomNumberGenerator.cs
+++ b/GearBox.Core/Utils/RandomNumberGenerator.cs
@@ -4,6 +4,8 @@ public class RandomNumberGenerator : IRandomNumberGenerator
 {
     public int Next(int max) => Random.Shared.Next(max);
 
+    public int Next(int minValue, int maxValue) => Random.Shared.Next(minValue, maxValue);
+
     public bool CheckChance(double percentChance)
     {
         if (percentChance == 0.0)

--- a/GearBox.Core/Utils/RandomNumberGenerator.cs
+++ b/GearBox.Core/Utils/RandomNumberGenerator.cs
@@ -1,0 +1,33 @@
+namespace GearBox.Core.Utils;
+
+public class RandomNumberGenerator : IRandomNumberGenerator
+{
+    public bool CheckChance(double percentChance)
+    {
+        if (percentChance == 0.0)
+        {
+            return false;
+        }
+        if (percentChance == 1.0)
+        {
+            return true;
+        }
+        if (percentChance > 1.0 || percentChance < 0.0)
+        {
+            throw new ArgumentException($"{nameof(percentChance)} should be between 0 and 1 (inclusive)");
+        }
+        return Random.Shared.NextDouble() < percentChance;
+    }
+
+    public T ChooseRandom<T>(List<T> options)
+    {
+        if (options.Count == 0)
+        {
+            throw new ArgumentException($"{nameof(options)} cannot be empty");
+        }
+
+        var index = Random.Shared.Next(options.Count);
+        var choice = options[index];
+        return choice;
+    }
+}

--- a/GearBox.Core/Utils/RandomNumberGenerator.cs
+++ b/GearBox.Core/Utils/RandomNumberGenerator.cs
@@ -2,6 +2,8 @@ namespace GearBox.Core.Utils;
 
 public class RandomNumberGenerator : IRandomNumberGenerator
 {
+    public int Next(int max) => Random.Shared.Next(max);
+
     public bool CheckChance(double percentChance)
     {
         if (percentChance == 0.0)
@@ -26,7 +28,7 @@ public class RandomNumberGenerator : IRandomNumberGenerator
             throw new ArgumentException($"{nameof(options)} cannot be empty");
         }
 
-        var index = Random.Shared.Next(options.Count);
+        var index = Next(options.Count);
         var choice = options[index];
         return choice;
     }

--- a/GearBox.Web/Infrastructure/GameResourceLoader.cs
+++ b/GearBox.Web/Infrastructure/GameResourceLoader.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using GearBox.Core.Model.Abilities.Actives;
 using GearBox.Core.Model.Areas;
 using GearBox.Core.Model.Items;
+using GearBox.Core.Utils;
 using GearBox.Web.Model.Json;
 
 namespace GearBox.Web.Infrastructure;
@@ -12,10 +13,12 @@ namespace GearBox.Web.Infrastructure;
 public class GameResourceLoader
 {
     private readonly IActiveAbilityFactory _actives;
+    private readonly IRandomNumberGenerator _rng;
 
-    public GameResourceLoader(IActiveAbilityFactory actives)
+    public GameResourceLoader(IActiveAbilityFactory actives, IRandomNumberGenerator rng)
     {
         _actives = actives;
+        _rng = rng;
     }
 
     public async Task<Map> LoadMapByName(string name)
@@ -28,7 +31,7 @@ public class GameResourceLoader
         var path = Path.Combine("game-resources", "maps", name + ".json");
         var text = await File.ReadAllTextAsync(path);
         var json = JsonSerializer.Deserialize<MapResourceJson>(text) ?? throw new ArgumentException($"Map not found: {name}");
-        return json.ToMap();
+        return json.ToMap(_rng);
     }
 
     public async Task<List<ItemUnion>> LoadAllItems()

--- a/GearBox.Web/Model/Json/MapResourceJson.cs
+++ b/GearBox.Web/Model/Json/MapResourceJson.cs
@@ -1,6 +1,7 @@
 using GearBox.Core.Model;
 using GearBox.Core.Model.Areas;
 using GearBox.Core.Model.Units;
+using GearBox.Core.Utils;
 
 namespace GearBox.Web.Model.Json;
 
@@ -16,13 +17,13 @@ public class MapResourceJson
     /// Attempts to convert from JSON to a map.
     /// Throws an exception if the JSON is not formatted properly.
     /// </summary>
-    public Map ToMap()
+    public Map ToMap(IRandomNumberGenerator rng)
     {
         var width = Tiles.Max(row => row.Count);
         var result = new Map(new Dimensions(
             Distance.FromTiles(Tiles.Count), 
             Distance.FromTiles(width)
-        ));
+        ), rng);
 
         foreach (var tileType in TileTypes)
         {

--- a/GearBox.Web/Program.cs
+++ b/GearBox.Web/Program.cs
@@ -11,6 +11,7 @@ using GearBox.Core.Model.GameObjects.Player;
 using Microsoft.AspNetCore.Identity.UI.Services;
 using Microsoft.AspNetCore.Identity;
 using GearBox.Core.Model.Areas;
+using GearBox.Core.Utils;
 
 /*
     Need to load some of the game resources in a specific order:
@@ -28,7 +29,8 @@ var gearboxConfig = new GearBoxConfig();
 webAppBuilder.Configuration
     .GetSection("GearBox")
     .Bind(gearboxConfig);
-var gameBuilder = new GameBuilder(gearboxConfig);
+var rng = new RandomNumberGenerator();
+var gameBuilder = new GameBuilder(gearboxConfig, rng);
 
 // configure actives before items
 gameBuilder.Actives
@@ -37,7 +39,7 @@ gameBuilder.Actives
     ;
 
 // configure items before crafting recipes and enemies
-var resourceLoader = new GameResourceLoader(gameBuilder.Actives);
+var resourceLoader = new GameResourceLoader(gameBuilder.Actives, rng);
 var itemResources = await resourceLoader.LoadAllItems();
 foreach (var item in itemResources)
 {


### PR DESCRIPTION
This PR injects an RNG interface into classes instead of using `Random.Shared` directly for #115 .

While this makes the code easier to test and more reusable, propagating `RandomNumberGenerator` down to each class is rather messy.
I'll likely refactor this later to make things cleaner.